### PR TITLE
added secrete angles for graph contruction

### DIFF
--- a/src/client_initialise_qubit_state.jl
+++ b/src/client_initialise_qubit_state.jl
@@ -12,8 +12,11 @@ init_plus_phase_state!(qureg,qᵢ,φᵢ)
 function init_plus_phase_state!(::Phase,qureg,qᵢ,φᵢ)
     qᵢ = c_shift_index(qᵢ)
     QuEST.hadamard(qureg,qᵢ)
-    QuEST.phaseShift(qureg,qᵢ,φᵢ)
+    QuEST.rotateZ(qureg,qᵢ,φᵢ)
+    #QuEST.phaseShift(qureg,qᵢ,φᵢ)
 end
+
+
 
 """
     plusState(qureg, qᵢ)

--- a/src/client_struct_utility_functions.jl
+++ b/src/client_struct_utility_functions.jl
@@ -41,7 +41,7 @@ function create_graph_resource(p::NamedTuple)::MBQCResourceState
     colors = MBQCColouringSet(p[:computation_colours],p[:test_colours])
     mbqc_graph = MBQCGraph(p[:graph],colors,input,output)
     mbqc_flow = MBQCFlow(p[:forward_flow],p[:backward_flow])
-    mbqc_angles = MBQCAngles(p[:angles])
+    mbqc_angles = MBQCAngles(p[:secret_angles],p[:public_angles])
     resource = MBQCResourceState(mbqc_graph,mbqc_flow,mbqc_angles)
     return resource
 end


### PR DESCRIPTION
Updated 

```juliua
struct MBQCAngles 
    secret_angles
    public_angles
end
```

to differentiate between the secrete angles and the public angles.

Which now is included 

```julia
function create_graph_resource(p::NamedTuple)::MBQCResourceState
    input = MBQCInput(p[:input_indices],p[:input_values]) 
    output = MBQCOutput(p[:output_indices])
    colors = MBQCColouringSet(p[:computation_colours],p[:test_colours])
    mbqc_graph = MBQCGraph(p[:graph],colors,input,output)
    mbqc_flow = MBQCFlow(p[:forward_flow],p[:backward_flow])
    mbqc_angles = MBQCAngles(p[:secret_angles],p[:public_angles])
    resource = MBQCResourceState(mbqc_graph,mbqc_flow,mbqc_angles)
    return resource
end
```